### PR TITLE
Removed empty lines in the generated csv file on Windows

### DIFF
--- a/tools/csv_generator/openpaygo_csv_generator.py
+++ b/tools/csv_generator/openpaygo_csv_generator.py
@@ -27,7 +27,7 @@ def generate_csv(serial_start, number_of_devices, config):
     firmware_version = base_config['firmware_version']
     filename = 'openpaygo_batch_' + number_to_serial(manufacturer_prefix, serial_start+1) + '-' + \
                number_to_serial(manufacturer_prefix, serial_start+number_of_devices) + '.csv'
-    with open(filename, 'w') as csvfile:
+    with open(filename, 'w', newline='') as csvfile:
         device_list_csv = csv.writer(csvfile, delimiter=',')
         headers = ['Serial Number', 'Starting Code', 'Key', 'Count', 'Time Divider', 'Restricted Digit Mode',
                    'Hardware Model', 'Firmware Version']


### PR DESCRIPTION
The `factory_flashing_tool.py` script can fail to read the CSV file generated by the `openpaygo_csv_generator.py` script because empty lines are not parsed correctly. The following error appears:

```
Traceback (most recent call last):
  File "c:\OpenPAYGO-Token\tools\factory_flasher\factory_flashing_tool.py", line 60, in <module>
    device_data_dict = {serial_number: (starting_code, key) for
  File "c:\OpenPAYGO-Token\tools\factory_flasher\factory_flashing_tool.py", line 60, in <dictcomp>
    device_data_dict = {serial_number: (starting_code, key) for
ValueError: not enough values to unpack (expected 8, got 0)
```

A fix has been added to the generator script to prevent this error. Tested on Windows 11.
