### PR TITLE
Fix `ModuleNotFoundError` when importing `openpaygo-token`

### DIFF
--- a/.github/workflows/openpaygo-token.yaml
+++ b/.github/workflows/openpaygo-token.yaml
@@ -1,0 +1,26 @@
+name: openpaygo-token
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-openpaygo-token:
+    name: Run Python Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Install `openpaygo-token`
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Run Python Tests
+        run: |
+          python tests/full_test_procedure.py
+          python tests/simple_scenario_test.py
+          python tests/test_spreadsheet_generator.py

--- a/openpaygo-token/decode_token.py
+++ b/openpaygo-token/decode_token.py
@@ -1,5 +1,5 @@
-from shared import OPAYGOShared
-from shared_extended import OPAYGOSharedExtended
+from .shared import OPAYGOShared
+from .shared_extended import OPAYGOSharedExtended
 
 
 class OPAYGODecoder(object):

--- a/openpaygo-token/encode_token.py
+++ b/openpaygo-token/encode_token.py
@@ -1,5 +1,5 @@
-from shared import OPAYGOShared
-from shared_extended import OPAYGOSharedExtended
+from .shared import OPAYGOShared
+from .shared_extended import OPAYGOSharedExtended
 
 
 class OPAYGOEncoder(object):

--- a/openpaygo-token/simulators/device_simulator.py
+++ b/openpaygo-token/simulators/device_simulator.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
-from shared import OPAYGOShared
-from decode_token import OPAYGODecoder
+from ..shared import OPAYGOShared
+from ..decode_token import OPAYGODecoder
 
 
 class DeviceSimulator(object):
@@ -37,7 +37,7 @@ class DeviceSimulator(object):
         else:
             token_int = int(token)
             return self._update_device_status_from_extended_token(token_int, show_result)
-    
+
     def get_days_remaining(self):
         if self.payg_enabled:
             td = self.expiration_date - datetime.now()

--- a/openpaygo-token/simulators/server_simulator.py
+++ b/openpaygo-token/simulators/server_simulator.py
@@ -1,6 +1,6 @@
 from datetime import datetime
-from encode_token import OPAYGOEncoder
-from shared import OPAYGOShared
+from ..encode_token import OPAYGOEncoder
+from ..shared import OPAYGOShared
 
 
 class SingleDeviceServerSimulator(object):

--- a/tests/full_test_procedure.py
+++ b/tests/full_test_procedure.py
@@ -1,7 +1,8 @@
-from .helpers import ADD_TIME, SET_TIME, DISABLE_VALUE, generate_from_device_data, test_accepted_validator, test_how_many_days_validator, test_name
-from openpaygo-token.simulators import DeviceSimulator
+from helpers import ADD_TIME, SET_TIME, DISABLE_VALUE, generate_from_device_data, test_accepted_validator, test_how_many_days_validator, test_name
 import codecs
 
+from importlib import import_module
+simulators = import_module("openpaygo-token.simulators")
 
 # This tests the device simulator against the full test procedure
 
@@ -64,12 +65,12 @@ def run_core_token_tests(device_data, device_simulator):
     test_how_many_days_validator(device_simulator, 'G12A', token_g12a, 0, description=test)
     device_data, token_g12b = generate_from_device_data(device_data, token_type=ADD_TIME, value_days=1)
     test_how_many_days_validator(device_simulator, 'G12B', token_g12b, 1)
-    
+
     return device_data
 
 
 def run_unordered_entry_tests(device_data, device_simulator):
-    
+
     test = 'We generate 3 Add Time tokens, then enter the 3rd, then first, then second and ensure the days are added properly'
     device_data, token_u1a = generate_from_device_data(device_data, token_type=SET_TIME, value_days=60)
     test_how_many_days_validator(device_simulator, 'U1A', token_u1a, 60, description=test)
@@ -108,7 +109,7 @@ if __name__ == '__main__':
         'time_divider': 1,
         'token_count': 1
     }
-    device_simulator = DeviceSimulator(device_data['starting_code'], codecs.decode(device_data['key'], 'hex'),
+    device_simulator = simulators.DeviceSimulator(device_data['starting_code'], codecs.decode(device_data['key'], 'hex'),
                                        restricted_digit_set=device_data['restricted_digit_set'],
                                        waiting_period_enabled=False)
     device_data = run_core_token_tests(device_data, device_simulator)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,7 @@
-from openpaygo-token import OPAYGOEncoder
 import codecs
+
+from importlib import import_module
+openpaygo_token = import_module("openpaygo-token")
 
 
 SET_TIME = 1
@@ -14,7 +16,7 @@ def generate_from_device_data(device_data, token_type, value_raw=None, value_day
     assert (value_days is not None) or (value_raw is not None)
     if value_raw is None:
         value_raw = value_days*device_data['time_divider']
-    device_data['token_count'], token = OPAYGOEncoder.generate_standard_token(
+    device_data['token_count'], token = openpaygo_token.OPAYGOEncoder.generate_standard_token(
         starting_code=device_data['starting_code'],
         key=codecs.decode(device_data['key'], 'hex'),
         value=value_raw,

--- a/tests/simple_scenario_test.py
+++ b/tests/simple_scenario_test.py
@@ -1,6 +1,8 @@
-from openpaygo-token.simulators import DeviceSimulator, SingleDeviceServerSimulator
-from openpaygo-token import OPAYGOShared
 from datetime import datetime, timedelta
+
+from importlib import import_module
+openpaygo_token = import_module("openpaygo-token")
+simulators = import_module("openpaygo-token.simulators")
 
 
 def assert_time_equals(time1, time2):
@@ -17,11 +19,11 @@ if __name__ == '__main__':
     restricted_digit_set = False
 
     print('Device: We initiate the device simulator with our device')
-    device_simulator = DeviceSimulator(device_starting_code, device_key,
+    device_simulator = simulators.DeviceSimulator(device_starting_code, device_key,
                                        restricted_digit_set=restricted_digit_set,
                                        waiting_period_enabled=False)
     print('Server: We initiate the server simulator with our device')
-    server_simulator = SingleDeviceServerSimulator(device_starting_code, device_key,
+    server_simulator = simulators.SingleDeviceServerSimulator(device_starting_code, device_key,
                                                    restricted_digit_set=restricted_digit_set)
 
     print('\n')
@@ -115,15 +117,15 @@ if __name__ == '__main__':
 
     print('\n')
     print('Server: We add generate 9 tokens each add-time of 1 day')
-    token_1 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_2 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_3 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_4 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_5 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_6 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_7 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_8 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_9 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_1 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_2 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_3 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_4 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_5 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_6 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_7 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_8 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_9 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
     print('Tokens: ', token_1, token_2, token_3, token_4, token_5, token_6, token_7, token_8, token_9)
     print('Device: We enter the 9th token into the device')
     device_simulator.enter_token(token_9)
@@ -147,8 +149,8 @@ if __name__ == '__main__':
 
     print('\n')
     print('Server: We add generate 2 tokens, first add-time and then set-time')
-    token_1 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
-    token_2 = server_simulator._generate_token_from_value(0, OPAYGOShared.TOKEN_TYPE_SET_TIME)
+    token_1 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_2 = server_simulator._generate_token_from_value(0, openpaygo_token.OPAYGOShared.TOKEN_TYPE_SET_TIME)
     print('Tokens: ', token_1, token_2)
     print('Device: We enter the 2nd token')
     device_simulator.enter_token(token_2)
@@ -165,8 +167,8 @@ if __name__ == '__main__':
 
     print('\n')
     print('Server: We add generate 2 tokens, first add-time and then set-time')
-    token_1 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_SET_TIME)
-    token_2 = server_simulator._generate_token_from_value(1, OPAYGOShared.TOKEN_TYPE_ADD_TIME)
+    token_1 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_SET_TIME)
+    token_2 = server_simulator._generate_token_from_value(1, openpaygo_token.OPAYGOShared.TOKEN_TYPE_ADD_TIME)
     print('Tokens: ', token_1, token_2)
     print('Device: We enter the 2nd token')
     device_simulator.enter_token(token_2)

--- a/tests/test_spreadsheet_generator.py
+++ b/tests/test_spreadsheet_generator.py
@@ -1,4 +1,4 @@
-from .helpers import ADD_TIME, SET_TIME, DISABLE_VALUE, generate_from_device_data, test_accepted, test_how_many_days, test_name
+from helpers import ADD_TIME, SET_TIME, DISABLE_VALUE, generate_from_device_data, test_accepted, test_how_many_days, test_name
 
 
 def run_core_token_tests(device_data):
@@ -59,12 +59,12 @@ def run_core_token_tests(device_data):
     test_how_many_days('G12A', token_g12a, 0, description=test)
     device_data, token_g12b = generate_from_device_data(device_data, token_type=ADD_TIME, value_days=1)
     test_how_many_days('G12B', token_g12b, 1)
-    
+
     return device_data
 
 
 def run_unordered_entry_tests(device_data):
-    
+
     test = 'We generate 3 Add Time tokens, then enter the 3rd, then first, then second and ensure the days are added properly'
     device_data, token_u1a = generate_from_device_data(device_data, token_type=SET_TIME, value_days=60)
     test_how_many_days('U1A', token_u1a, 60, description=test)


### PR DESCRIPTION
Scope of this is to make the following commands execute without errors:

```
pip install -e .
python tests/full_test_procedure.py
python tests/simple_scenario_test.py
python tests/test_spreadsheet_generator.py
```

Closes: #23 