### PR TITLE
Fixed sequential serial number generation

### DIFF
--- a/tools/csv_generator/openpaygo_csv_generator.py
+++ b/tools/csv_generator/openpaygo_csv_generator.py
@@ -32,7 +32,7 @@ def generate_csv(serial_start, number_of_devices, config):
         headers = ['Serial Number', 'Starting Code', 'Key', 'Count', 'Time Divider', 'Restricted Digit Mode',
                    'Hardware Model', 'Firmware Version']
         device_list_csv.writerow(headers)
-        for number in range(1, number_of_devices+1):
+        for number in range(serial_start + 1, serial_start + number_of_devices + 1):
             device_serial = number_to_serial(manufacturer_prefix, number)
             starting_code = random.randint(1, 999999999)
             key = codecs.encode(os.urandom(16), 'hex').decode('utf-8')


### PR DESCRIPTION
If the `openpaygo_csv_generator.py` script is run more than once indicating a different _last serial number_, the serial numbers inside the generated csv file always start from 1.

For example using the following `openpaygo_csv_generator.conf` file:

```
[BASE_CONFIG]
manufacturer_prefix = TEST
time_divider = 1
restricted_digit_set = 0
hardware_model = 0000
firmware_version = 

[BATCH_CONFIG]
last_generated = 0
```

Produces this csv file after a first call:
[openpaygo_batch_TEST000000001-TEST000000005.csv](https://github.com/EnAccess/OpenPAYGO-Token/files/10929971/openpaygo_batch_TEST000000001-TEST000000005.csv)

And this csv file after a second call (indicating that the last serial number was 5):
[openpaygo_batch_TEST000000006-TEST000000010.csv](https://github.com/EnAccess/OpenPAYGO-Token/files/10929967/openpaygo_batch_TEST000000006-TEST000000010.csv)

The naming of the files is correct (1 to 5 and 6 to 10) but inside the serial numbers are wrong.

After the fix we get the following csv files with the expected serial numbers:
[openpaygo_batch_TEST000000001-TEST000000005.csv](https://github.com/EnAccess/OpenPAYGO-Token/files/10930005/openpaygo_batch_TEST000000001-TEST000000005.csv)
[openpaygo_batch_TEST000000006-TEST000000010.csv](https://github.com/EnAccess/OpenPAYGO-Token/files/10930004/openpaygo_batch_TEST000000006-TEST000000010.csv)