### PR TITLE
Fixed printing in device_simulator

### DIFF
--- a/openpaygo-token/simulators/device_simulator.py
+++ b/openpaygo-token/simulators/device_simulator.py
@@ -105,7 +105,7 @@ class DeviceSimulator(object):
                 self._update_expiration_date_from_value(token_value, token_type)
         elif token_value == OPAYGOShared.PAYG_DISABLE_VALUE:
             self.payg_enabled = False
-        elif token_value != OPAYGOShared.COUNTER_SYNC_VALUE:
+        elif token_value == OPAYGOShared.COUNTER_SYNC_VALUE:
             # We do nothing if its the sync counter value, the counter has been synced already
             print('COUNTER_SYNCED')
         else:


### PR DESCRIPTION
The device_simulator prints a faulty UNKNOWN_COMMAND for sync token entry, instead of the COUNTER_SYNCED string.